### PR TITLE
Resolved netlify deploy issue

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,6 +4,6 @@
 #  publish = "build" # create-react-app builds to this folder, Netlify should serve all these files statically
 
 [build]
-  Command = "npm run build"
+  Command = "yarn build"
   Functions = "lambda"
   Publish = "build"

--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,6 @@ import * as serviceWorker from './serviceWorker';
 const link = `
   color: 'hsla(205.9, 85.3%, 40%, 1)';
   text-decoration: none;
-  
 `;
 
 const themes = {
@@ -45,4 +44,4 @@ ReactDOM.render(
 // If you want your app to work offline and load faster, you can change
 // unregister() to register() below. Note this comes with some pitfalls.
 // Learn more about service workers: http://bit.ly/CRA-PWA
-serviceWorker.register();
+serviceWorker.unregister();

--- a/src/pages/PostsList.tsx
+++ b/src/pages/PostsList.tsx
@@ -37,7 +37,7 @@ const StyledPosts = styled.div`
   max-width: 600px;
   margin: 0 auto;
   a {
-    background: orange;
+    background: yellow;
   }
 
   div:first-child {


### PR DESCRIPTION
netlify deploys were stale only on the prod site, updates wouldn't be reflected. Preview URLs worked. It looks like the issue was caused by service workers being enabled and so the prod url was cached. 

Disabled service workers.